### PR TITLE
Sobescreve classe TokenRepository para resolver problema com tipos de…

### DIFF
--- a/src/MongodbPassportServiceProvider.php
+++ b/src/MongodbPassportServiceProvider.php
@@ -32,5 +32,9 @@ class MongodbPassportServiceProvider extends ServiceProvider
         $this->app->extend(PassportClientCommand::class, function () {
             return new ClientCommand();
         });
+
+        $this->app->bind(PassportTokenRepository::class, function () {
+            return $this->app->make(TokenRepository::class);
+        });
     }
 }

--- a/src/Passport/TokenRepository.php
+++ b/src/Passport/TokenRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Sysvale\Mongodb\Passport;
+
+use Laravel\Passport\TokenRepository as PassportTokenRepository;
+
+class TokenRepository extends PassportTokenRepository
+{
+   /**
+     * Store the given token instance.
+     *
+     * @param  \Laravel\Passport\Token  $token
+     * @return void
+     */
+
+    public function save($token)
+    {
+        $token->save();
+    }
+
+}


### PR DESCRIPTION
A classe TokenRepository recebe no meu método save() o tipo Token. Isso causa um erro citado

    https://github.com/laravel/passport/issues/968.

A mudança feita sobscreve a classe TokenRepository alterando o suporte para um tipo genérico.